### PR TITLE
ignore wacom devices

### DIFF
--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -219,6 +219,11 @@ else:
                 Logger.debug('ProbeSysfs: found device: %s at %s' % (
                     device.name, device.device))
 
+                # dirty hack to ignore wacom devices, these devices does not
+                #   function very well when using hidinput as provider.
+                if match(device.name, 'wacom', IGNORECASE):
+                    continue
+
                 # must ignore ?
                 if self.match:
                     if self.use_regex:


### PR DESCRIPTION
probesysfs uses hidinput as provider/driverfor wacom devices, which behave abnormally.  use linuxwacom provider/driver instead.