### PR TITLE
Ignore Wacom devices

### DIFF
--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -101,9 +101,9 @@ cdef class _WindowSDL2Storage:
         elif state == 'hidden':
             self.win_flags |= SDL_WINDOW_HIDDEN
 
-        #dispmanx_layer = environ.get('KIVY_BCM_DISPMANX_LAYER', '0')
-        #SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, dispmanx_layer)
-        SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, b'0')
+        dispmanx_layer = environ.get('KIVY_BCM_DISPMANX_LAYER', '0')
+        SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, dispmanx_layer)
+        #SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, b'0')
 
         SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, b'0')
 

--- a/kivy/core/window/_window_sdl2.pyx
+++ b/kivy/core/window/_window_sdl2.pyx
@@ -101,6 +101,10 @@ cdef class _WindowSDL2Storage:
         elif state == 'hidden':
             self.win_flags |= SDL_WINDOW_HIDDEN
 
+        #dispmanx_layer = environ.get('KIVY_BCM_DISPMANX_LAYER', '0')
+        #SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, dispmanx_layer)
+        SDL_SetHint(SDL_HINT_RPI_VIDEO_LAYER, b'0')
+
         SDL_SetHint(SDL_HINT_ACCELEROMETER_AS_JOYSTICK, b'0')
 
         SDL_SetHintWithPriority(b'SDL_ANDROID_TRAP_BACK_BUTTON', b'1',

--- a/kivy/input/providers/probesysfs.py
+++ b/kivy/input/providers/probesysfs.py
@@ -219,6 +219,12 @@ else:
                 Logger.debug('ProbeSysfs: found device: %s at %s' % (
                     device.name, device.device))
 
+                # dirty hack to ignore wacom devices, these devices does not
+                #   function very well when using hidinput as provider.
+                if 'acom' in device.name:
+                    Logger.info('ProbeSysfs: Ignoring ' + device.name)
+                    continue
+
                 # must ignore ?
                 if self.match:
                     if self.use_regex:

--- a/kivy/lib/sdl2.pxi
+++ b/kivy/lib/sdl2.pxi
@@ -454,6 +454,7 @@ cdef extern from "SDL.h":
     cdef char *SDL_HINT_VIDEO_WIN_D3DCOMPILER
     cdef char *SDL_HINT_ACCELEROMETER_AS_JOYSTICK
     cdef char *SDL_HINT_ANDROID_TRAP_BACK_BUTTON
+    cdef char *SDL_HINT_RPI_VIDEO_LAYER
 
     cdef int SDL_QUERY               = -1
     cdef int SDL_IGNORE              =  0


### PR DESCRIPTION
Probesysfs uses hidinput as provider/driver(?) for Wacom devices, which make them behave abnormally.  Use linuxwacom instead.